### PR TITLE
Minor URL fixes

### DIFF
--- a/data.json
+++ b/data.json
@@ -5536,7 +5536,7 @@
 			"dropouttv_productid": "s01e28",
 			"title": "Tournament of Champions Pt. 4",
 			"description": "Champions Jared Logan, Siobhan Thompson, and Jon Gutierrez compete for the title of Most Correct.",
-			"url": "httpshttps://www.dropout.tv/um-actually/season:1/videos/tournament-of-champions-pt-4",
+			"url": "https://www.dropout.tv/um-actually/season:1/videos/tournament-of-champions-pt-4",
 			"thumbnail_landscape": "images/s01e28.jpg",
 			"duration": 2040,
 			"number": "28",

--- a/data.json
+++ b/data.json
@@ -9575,7 +9575,7 @@
 			"dropouttv_productid": "s03e07",
 			"title": "God of War, Spirited Away, Dance Dance Revolution",
 			"description": "Ify Nwadiwe, Emma Fyffe, and Liam Senior fix a wrong Rubik's Cube and remember Redwall rodents.",
-			"url": "https://www.dropout.tv/featured/videos/god-of-war-spirited-away-dance-dance-revolution",
+			"url": "https://www.dropout.tv/um-actually/season:3/videos/god-of-war-spirited-away-dance-dance-revolution",
 			"thumbnail_landscape": "images/s03e07.jpg",
 			"duration": 1840,
 			"number": "7",


### PR DESCRIPTION
I was playing with the data today (thanks Ify for shouting out umactually.info!) and noticed some of the URLs aren't correct.

One of these is just malformed and the other seems like it was featured on the home page at some point, but now points to the correct (and more solid) location.